### PR TITLE
AU-25 - Create a new CLI command to deploy to S3 bucket

### DIFF
--- a/src/deploy/schema.json
+++ b/src/deploy/schema.json
@@ -30,7 +30,7 @@
       "type": "string",
       "description": "AWS bucket to be used."
     },
-    "subFolder": {
+    "outputDir": {
       "type": "string",
       "description": "AWS bucket output directory."
     }

--- a/src/deploy/schema.json
+++ b/src/deploy/schema.json
@@ -32,7 +32,7 @@
     },
     "subFolder": {
       "type": "string",
-      "description": "Subfolder from AWS bucket."
+      "description": "AWS bucket output directory."
     }
   }
 }

--- a/src/deploy/schema.json
+++ b/src/deploy/schema.json
@@ -21,6 +21,18 @@
     "targetDir": {
       "type": "string",
       "description": "This is one of the options you can freely choose according to your needs. --- We will 'deploy' to this folder."
+    },
+    "region": {
+      "type": "string",
+      "description": "AWS Region for deployment."
+    },
+    "bucket": {
+      "type": "string",
+      "description": "AWS bucket to be used."
+    },
+    "subFolder": {
+      "type": "string",
+      "description": "Subfolder from AWS bucket."
     }
   }
 }

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -11,7 +11,7 @@ export async function run(
     const util = require('util');
     const exec = util.promisify(require('child_process').exec);
 
-    const bucketPath: string = options.subFolder ? options.subFolder : '';
+    const bucketPath: string = options.subFolder ? `/${options.subFolder}` : '';
     const { stdout } = await exec(
       `aws s3 sync --acl public-read --delete ${dir} s3://${options.bucket}${bucketPath} --region ${options.region}`
     );

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -11,7 +11,7 @@ export async function run(
     const util = require('util');
     const exec = util.promisify(require('child_process').exec);
 
-    const bucketPath: string = options.subFolder ? `/${options.subFolder}` : '';
+    const bucketPath: string = options.outputDir ? `/${options.outputDir}` : '';
     const { stdout } = await exec(
       `aws s3 sync --acl public-read --delete ${dir} s3://${options.bucket}${bucketPath} --region ${options.region}`
     );

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -1,27 +1,25 @@
 import { logging } from '@angular-devkit/core';
-import * as fse from 'fs-extra';
 
 import { Schema } from '../deploy/schema';
 
-// TODO: add your deployment code here!
 export async function run(
   dir: string,
   options: Schema,
   logger: logging.LoggerApi
 ) {
   try {
-    // options.targetDir = options.targetDir || '/example-folder';
+    const util = require('util');
+    const exec = util.promisify(require('child_process').exec);
 
-    // if (!(await fse.pathExists(options.targetDir))) {
-    //   throw new Error(`Target directory ${options.targetDir} does not exist!`);
-    // }
+    const bucketPath: string = options.subFolder ? options.subFolder : '';
+    const { stdout } = await exec(
+      `aws s3 sync --acl public-read --delete ${dir} s3://${options.bucket}${bucketPath} --region ${options.region}`
+    );
 
-    // await fse.copy(dir, options.targetDir);
-
-    console.log({ dir, options });
-    logger.info('🚀 Successfully published via nx-deploy-s3! Have a nice day!');
-  } catch (error) {
-    logger.error('❌ An error occurred!');
-    throw error;
+    logger.info(`Successfully deployed application.`);
+    logger.info(stdout);
+  } catch (e) {
+    logger.error(`Failed to deploy application.`);
+    logger.error(e.message);
   }
 }


### PR DESCRIPTION
In order to allow for command-line deployment to an AWS s3 bucket with `nx deploy` in the dxp-web application, we needed to incorporate a library to create and use a CLI builder. 

This PR introduces custom changes to the chosen [Nx deployment builder](https://github.com/mpezzi/nx-deploy-s3), such that we can now define an s3 bucket to deploy to, the region of this bucket, and any bucket subfolders to deploy to. This builder utilizes the AWS CLI to sync the local built directory to the files present in the deployed bucket.